### PR TITLE
Fix 10 9 2020

### DIFF
--- a/cvn/cvn/config/entity.py
+++ b/cvn/cvn/config/entity.py
@@ -312,11 +312,11 @@ class Entity:
                 self.node = BNode()
             return self.node
         if self.should_cache():
-            if cvn_entity_cache.get_current_entity_cache().in_cache(self.get_cache_id()):
-                return cvn_entity_cache.get_current_entity_cache().get(self.get_cache_id())
+            if cvn_entity_cache.get_current_entity_cache().in_cache(self.get_cache_id().lower()):
+                return cvn_entity_cache.get_current_entity_cache().get(self.get_cache_id().lower())
             else:
                 uri = URIRef(self.get_identifier())
-                cvn_entity_cache.get_current_entity_cache().add_to_cache(self.get_cache_id(), uri)
+                cvn_entity_cache.get_current_entity_cache().add_to_cache(self.get_cache_id().lower(), uri)
                 return uri
         return URIRef(self.get_identifier())
 

--- a/cvn/mappings/cvn/1.4.2_sp1/cvn-to-roh/entities.toml
+++ b/cvn/mappings/cvn/1.4.2_sp1/cvn-to-roh/entities.toml
@@ -1669,16 +1669,33 @@ classname = "AwardedDegree"
     inverse_name = "relates"
     link_to_cvn_person = true
 
-    [[entities.properties]]
-    ontology = "vivo"
-    name = "dateTime"
-    format = "{date}"
-    datatype = "xsd:datetime"
+    [[entities.subentities]]
+    displayname = "vivo:DateTimeValue"
 
-        [[entities.properties.sources]]
+        [[entities.subentities.relationships]]
+        inverse = "vivo:dateTimeValue"
+
+        [[entities.subentities.properties]]
+        ontology = "vivo"
+        name = "dateTime"
+        format = "{date}"
+        datatype = "xsd:datetime"
+
+        [[entities.subentities.properties.sources]]
         code = "020.010.010.130"
         name = "date"
         bean = "Value"
+
+    # [[entities.properties]]
+    # ontology = "vivo"
+    # name = "dateTime"
+    # format = "{date}"
+    # datatype = "xsd:datetime"
+
+    #     [[entities.properties.sources]]
+    #     code = "020.010.010.130"
+    #     name = "date"
+    #     bean = "Value"
 
     [[entities.subentities]]
     ontology = "vivo"

--- a/cvn/mappings/cvn/1.4.2_sp1/cvn-to-roh/entities.toml
+++ b/cvn/mappings/cvn/1.4.2_sp1/cvn-to-roh/entities.toml
@@ -44,7 +44,7 @@ cache = "foaf:person"
         inverse = "roh:hasContactInfo"
 
         [[entities.subentities.subentities]]
-        displayname = "vcard:Addresss"
+        displayname = "vcard:Address"
 
             [[entities.subentities.subentities.relationships]]
             inverse = "vcard:hasAddress"

--- a/cvn/mappings/cvn/1.4.2_sp1/cvn-to-roh/entities.toml
+++ b/cvn/mappings/cvn/1.4.2_sp1/cvn-to-roh/entities.toml
@@ -9,7 +9,7 @@ cache = "foaf:person"
     # DEBUG -- para marcar a la persona primaria del CVN.
     # Eliminar, sustituir o cambiar según proceda.
     [[entities.properties]]
-    displayname = "roh:debugPrimary"
+    displayname = "foaf:primaryTopic"
     datatype = "xsd:boolean"
 
         # Debug: este código no existe, pero lo sobreescribimos con "value"


### PR DESCRIPTION
Arreglados los siguientes fallos:

1.- La entidad http://purl.org/roh/mirror/vivo#AwardedDegree tiene una propiedad http://purl.org/roh/mirror/vivo#dateTime según la ontología debería ser http://purl.org/roh/mirror/vivo#dateTimeValue

2.- La entidad http://purl.org/roh/mirror/vcard#Addresss no existe en la ontología


3.- Marcar la entidad principal del CVN:

De alguna manera hay que marcar la entidad persona ‘Dueña’ del CV, con alguna propiedad o lo que nos aconsejéis, para que después podamos tratarla de una forma especial, ahora mismo en un CV llegan varias personas, pero no se sabe cual es la entidad principal (Persona dueña del CV). ¿Se va a quedar ‘roh:debugPrimary'?
 

5.- Las entidades del tipo http://purl.org/roh/mirror/vivo#AcademicDegree con el mismo nombre deberían de ser únicas (ahora se generan N AcademicDegree con el mismo nombre.)

Funciona bien si son iguales mayúsculas y minúsculas, pero en el ejemplo están ‘Ingeniero en Informática’ y ‘INGENIERO EN INFORMÁTICA’ deberían figurar sólo una vez.